### PR TITLE
Update specialKeys for keybindings and export EmacsHandler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ var specialKey: Record<string, string> = {
 var ignoredKeys: any = { Shift: 1, Alt: 1, Command: 1, Control: 1, CapsLock: 1 };
 
 const commandKeyBinding: Record<string, any> = {}
-class EmacsHandler {
+export class EmacsHandler {
   static bindKey(keyGroup: string, command: any) {
     keyGroup.split("|").forEach(function (binding) {
       let chain = "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,8 @@ var specialKey: Record<string, string> = {
   Return: 'Return', Escape: 'Esc', Insert: 'Ins',
   ArrowLeft: 'Left', ArrowRight: 'Right', ArrowUp: 'Up', ArrowDown: 'Down',
   Enter: 'Return', Divide: '/', Slash: '/', Multiply: '*',
-  Subtract: '-', Minus: "-", Equal: '=',
+  Subtract: '-', Minus: "-", Equal: '=', Semicolon: ';', Comma: ',',
+  Period: '.',
 };
 var ignoredKeys: any = { Shift: 1, Alt: 1, Command: 1, Control: 1, CapsLock: 1 };
 


### PR DESCRIPTION
`specialKey` is updated with more special characters, so that `A-;`, `M-<`, `M->` works.

`EmacsHandler` is exported s.t. keybindings can be added via `EmacsHandler.bindKey()`. 